### PR TITLE
Account password hiding can be configured in options

### DIFF
--- a/src/com/_17od/upm/gui/AccountDialog.java
+++ b/src/com/_17od/upm/gui/AccountDialog.java
@@ -46,6 +46,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
 import com._17od.upm.database.AccountInformation;
+import com._17od.upm.util.Preferences;
 import com._17od.upm.util.Translator;
 
 
@@ -232,6 +233,12 @@ public class AccountDialog extends EscapeDialog {
                 }
             }
         });
+
+        Boolean hideAccountPassword = new Boolean(
+                Preferences
+                        .get(Preferences.ApplicationOptions.ACCOUNT_HIDE_PASSWORD));
+        hidePasswordCheckbox.setSelected(hideAccountPassword.booleanValue());
+        
         c.gridx = 2;
         c.gridy = 0;
         c.anchor = GridBagConstraints.LINE_START;

--- a/src/com/_17od/upm/gui/OptionsDialog.java
+++ b/src/com/_17od/upm/gui/OptionsDialog.java
@@ -57,6 +57,7 @@ public class OptionsDialog extends EscapeDialog {
 
     private JTextField dbToLoadOnStartup;
     private JCheckBox enableProxyCheckbox;
+    private JCheckBox hideAccountPasswordCheckbox;
     private JTextField httpProxyHost;
     private JTextField httpProxyPort;
     private JTextField httpProxyUsername;
@@ -176,6 +177,20 @@ public class OptionsDialog extends EscapeDialog {
         c.fill = GridBagConstraints.HORIZONTAL;
         mainPanel.add(localeComboBox, c);
 
+        // The "Hide account password" row
+        Boolean hideAccountPassword = new Boolean(Preferences.get(Preferences.ApplicationOptions.ACCOUNT_HIDE_PASSWORD));
+        hideAccountPasswordCheckbox = new JCheckBox(Translator.translate("hideAccountPassword"), hideAccountPassword.booleanValue());
+        c.gridx = 0;
+        c.gridy = 4;
+        c.anchor = GridBagConstraints.LINE_START;
+        c.insets = new Insets(0, 2, 5, 0);
+        c.weightx = 1;
+        c.weighty = 0;
+        c.gridwidth = 1;
+        c.fill = GridBagConstraints.NONE;
+        mainPanel.add(hideAccountPasswordCheckbox, c);
+        
+        
         // Some spacing
         emptyBorderPanel.add(Box.createVerticalGlue());
 
@@ -379,6 +394,7 @@ public class OptionsDialog extends EscapeDialog {
     private void okButtonAction() {
         try {
             Preferences.set(Preferences.ApplicationOptions.DB_TO_LOAD_ON_STARTUP, dbToLoadOnStartup.getText());
+            Preferences.set(Preferences.ApplicationOptions.ACCOUNT_HIDE_PASSWORD, String.valueOf(hideAccountPasswordCheckbox.isSelected()));
             Preferences.set(Preferences.ApplicationOptions.HTTP_PROXY_HOST, httpProxyHost.getText());
             Preferences.set(Preferences.ApplicationOptions.HTTP_PROXY_PORT, httpProxyPort.getText());
             Preferences.set(Preferences.ApplicationOptions.HTTP_PROXY_USERNAME, httpProxyUsername.getText());

--- a/src/com/_17od/upm/util/Preferences.java
+++ b/src/com/_17od/upm/util/Preferences.java
@@ -39,6 +39,8 @@ public class Preferences {
     public class ApplicationOptions {
         public static final String DB_TO_LOAD_ON_STARTUP= "DBToLoadOnStartup";
 
+        public static final String ACCOUNT_HIDE_PASSWORD="account.hidePassword";
+
         public static final String HTTP_PROXY_ENABLED="http.proxy.enabled";
         public static final String HTTP_PROXY_HOST="http.proxy.host";
         public static final String HTTP_PROXY_PORT="http.proxy.port";

--- a/src/upm.properties
+++ b/src/upm.properties
@@ -88,6 +88,7 @@ generate = Generate
 options = Options
 general = General
 dbToLoadOnStartup = Database To Load On Startup
+hideAccountPassword = Hide Account Password by default
 enableProxy = Enable Proxy
 httpProxy = HTTP Proxy
 port = Port

--- a/src/upm_de.properties
+++ b/src/upm_de.properties
@@ -79,6 +79,7 @@ accountAlreadyExists = Konto existiert bereits...
 options = Optionen
 general = Allgemein
 dbToLoadOnStartup = Beim Start zu ladende Datenbank
+hideAccountPassword = Konto-Passwort standardm‰ﬂig verstecken
 enableProxy = Proxy benutzen
 httpProxy = HTTP Proxy
 port = Port


### PR DESCRIPTION
Hi Adrian,

when I browse the account list, I quickly want to see the password. I didn't like the way I had to disable the password hiding each time.

So I created a preference to set the default "hidden"-state of the password field.

Greetings from Berlin,
Olaf
