### PR TITLE
Persistence for the remote database location + some warnings fixed

### DIFF
--- a/src/com/_17od/upm/gui/AccountDialog.java
+++ b/src/com/_17od/upm/gui/AccountDialog.java
@@ -398,7 +398,7 @@ public class AccountDialog extends EscapeDialog {
             if (!pAccount.getUserId().equals(userId.getText())) {
                 accountChanged = true;
             }
-            if (!pAccount.getPassword().equals(password.getText())) {
+            if (!pAccount.getPassword().equals(password.getPassword())) {
                 accountChanged = true;
             }
             if (!pAccount.getUrl().equals(url.getText())) {
@@ -410,7 +410,7 @@ public class AccountDialog extends EscapeDialog {
 
             pAccount.setAccountName(accountName.getText().trim());
             pAccount.setUserId(userId.getText());
-            pAccount.setPassword(password.getText());
+            pAccount.setPassword(new String(password.getPassword()));
             pAccount.setUrl(url.getText());
             pAccount.setNotes(notes.getText());
             

--- a/src/com/_17od/upm/gui/MainWindow.java
+++ b/src/com/_17od/upm/gui/MainWindow.java
@@ -166,13 +166,25 @@ public class MainWindow extends JFrame implements ActionListener {
 
         try {
             //Load the startup database if it's configured
+        	String url = Preferences.get(Preferences.ApplicationOptions.HTTP_DATABASE_URL);
+        	String username = Preferences.get(Preferences.ApplicationOptions.HTTP_DATABASE_USER);
+        	String password = Preferences.get(Preferences.ApplicationOptions.HTTP_DATABASE_PASSWORD);
             String db = Preferences.get(Preferences.ApplicationOptions.DB_TO_LOAD_ON_STARTUP);
+ 
             if (db != null && !db.equals("")) {
-                File dbFile = new File(db);
-                if (!dbFile.exists()) {
-                    dbActions.errorHandler(new Exception(Translator.translate("dbDoesNotExist", db)));
-                } else {
-                    dbActions.openDatabase(db);
+            	
+            	if (url != null && !url.equals(""))
+            	{
+                    dbActions.openDatabaseFromURL(url, username, password, db);
+            	}
+            	else
+            	{
+                    File dbFile = new File(db);
+                    if (!dbFile.exists()) {
+                        dbActions.errorHandler(new Exception(Translator.translate("dbDoesNotExist", db)));
+                    } else {
+                        dbActions.openDatabase(db);
+                    }
                 }
             }
         } catch (Exception e) {

--- a/src/com/_17od/upm/util/Preferences.java
+++ b/src/com/_17od/upm/util/Preferences.java
@@ -53,6 +53,9 @@ public class Preferences {
         public static final String HTTP_PROXY_USERNAME="http.proxy.username";
         public static final String HTTP_PROXY_PASSWORD="http.proxy.password";
         public static final String HTTPS_ACCEPT_SELFSIGNED_CERTS="https.accept.selfsigned.certs";
+        public static final String HTTP_DATABASE_USER="http.database.user";
+        public static final String HTTP_DATABASE_PASSWORD="http.database.password";
+        public static final String HTTP_DATABASE_URL="http.database.url";
         
         public static final String LOCALE="locale";
     }

--- a/test/com/_17od/upm/database/TestAccountInformation.java
+++ b/test/com/_17od/upm/database/TestAccountInformation.java
@@ -72,7 +72,7 @@ public class TestAccountInformation extends TestCase {
     public void testAssembleCharsInFieldLength() throws IOException {
         ByteArrayInputStream is = new ByteArrayInputStream("bad input".getBytes());
         try {
-            AccountInformation ai = new AccountInformation(is);
+            new AccountInformation(is);
             fail("Should have got an ProblemReadingDatabaseFile exception now");
         } catch (ProblemReadingDatabaseFile e ) {
             //ok to get here
@@ -83,7 +83,7 @@ public class TestAccountInformation extends TestCase {
     public void testAssembleBadFieldLength() throws IOException, ProblemReadingDatabaseFile {
         ByteArrayInputStream is = new ByteArrayInputStream("0".getBytes());
         try {
-            AccountInformation ai = new AccountInformation(is);
+            new AccountInformation(is);
             fail("Should have got an EOFException exception now");
         } catch (EOFException e ) {
             //ok to get here
@@ -94,7 +94,7 @@ public class TestAccountInformation extends TestCase {
     public void testAssembleBadFieldContents() throws IOException, ProblemReadingDatabaseFile {
         ByteArrayInputStream is = new ByteArrayInputStream("0004".getBytes());
         try {
-            AccountInformation ai = new AccountInformation(is);
+            new AccountInformation(is);
             fail("Should have got an EOFException exception now");
         } catch (EOFException e ) {
             //ok to get here


### PR DESCRIPTION
1. Fixed some javac warnings :
   - .show()-> .setVisible(true
   - .getText()->getPassword()
   - Implemented persistency for remote reporsitory URLs.
     It works similarly to the android version and persists the
     HTTP url, user name and password.
     On startup it checks if there's an URL persisted and if there is
     it overwrites the db file location with the download.
