### PR TITLE
Disabled selecting of all text when Notes field gains focus

### DIFF
--- a/src/com/_17od/upm/gui/AccountDialog.java
+++ b/src/com/_17od/upm/gui/AccountDialog.java
@@ -371,12 +371,6 @@ public class AccountDialog extends EscapeDialog {
         c.gridwidth = 2;
         c.fill = GridBagConstraints.BOTH;
         container.add(notesScrollPane, c);
-        notes.addFocusListener(new FocusAdapter() {
-            public void focusGained(FocusEvent e) {
-                notes.selectAll();
-            }
-        });
-
 
         //Seperator Row
         JSeparator sep = new JSeparator();


### PR DESCRIPTION
This pull request is to prevent the selecting of all text when the Notes text area gains focus. This is in response to Issue #32.
