### PR TITLE
Moved setButtonState() from DatabaseActions to MainWindow

### DIFF
--- a/src/com/_17od/upm/gui/DatabaseActions.java
+++ b/src/com/_17od/upm/gui/DatabaseActions.java
@@ -587,36 +587,7 @@ public class DatabaseActions {
             listview.addElement(accountNames.get(i));
         }
 
-        setButtonState();
-    }
-
-
-    public void setButtonState() {
-        if (mainWindow.getAccountsListview().getSelectedValue() == null) {
-            mainWindow.getEditAccountButton().setEnabled(false);
-            mainWindow.getCopyUsernameButton().setEnabled(false);
-            mainWindow.getCopyPasswordButton().setEnabled(false);
-            mainWindow.getLaunchURLButton().setEnabled(false);
-            mainWindow.getDeleteAccountButton().setEnabled(false);
-            mainWindow.getEditAccountMenuItem().setEnabled(false);
-            mainWindow.getCopyUsernameMenuItem().setEnabled(false);
-            mainWindow.getCopyPasswordMenuItem().setEnabled(false);
-            mainWindow.getLaunchURLMenuItem().setEnabled(false);
-            mainWindow.getDeleteAccountMenuItem().setEnabled(false);
-            mainWindow.getViewAccountMenuItem().setEnabled(false);
-        } else {
-            mainWindow.getEditAccountButton().setEnabled(true);
-            mainWindow.getCopyUsernameButton().setEnabled(true);
-            mainWindow.getCopyPasswordButton().setEnabled(true);
-            mainWindow.getLaunchURLButton().setEnabled(true);
-            mainWindow.getDeleteAccountButton().setEnabled(true);
-            mainWindow.getEditAccountMenuItem().setEnabled(true);
-            mainWindow.getCopyUsernameMenuItem().setEnabled(true);
-            mainWindow.getCopyPasswordMenuItem().setEnabled(true);
-            mainWindow.getLaunchURLMenuItem().setEnabled(true);
-            mainWindow.getDeleteAccountMenuItem().setEnabled(true);
-            mainWindow.getViewAccountMenuItem().setEnabled(true);
-        }
+        mainWindow.setButtonState();
     }
 
 

--- a/src/com/_17od/upm/gui/MainWindow.java
+++ b/src/com/_17od/upm/gui/MainWindow.java
@@ -384,7 +384,7 @@ public class MainWindow extends JFrame implements ActionListener {
 		});
 		accountsListview.addListSelectionListener(new ListSelectionListener() {
 			public void valueChanged(ListSelectionEvent e) {
-				dbActions.setButtonState();
+				setButtonState();
 			}
 		});
 		accountsListview.addMouseListener(new MouseAdapter() {
@@ -1147,6 +1147,34 @@ public class MainWindow extends JFrame implements ActionListener {
 		optionsButton.setToolTipText(Translator.translate(OPTIONS_TXT));
 		syncDatabaseButton.setToolTipText(Translator.translate(SYNC_DATABASE_TXT));
 		resetSearchButton.setToolTipText(Translator.translate(RESET_SEARCH_TXT));
+	}
+	
+	public void setButtonState() {
+		if (getAccountsListview().getSelectedValue() == null) {
+			getEditAccountButton().setEnabled(false);
+			getCopyUsernameButton().setEnabled(false);
+			getCopyPasswordButton().setEnabled(false);
+			getLaunchURLButton().setEnabled(false);
+			getDeleteAccountButton().setEnabled(false);
+			getEditAccountMenuItem().setEnabled(false);
+			getCopyUsernameMenuItem().setEnabled(false);
+			getCopyPasswordMenuItem().setEnabled(false);
+			getLaunchURLMenuItem().setEnabled(false);
+			getDeleteAccountMenuItem().setEnabled(false);
+			getViewAccountMenuItem().setEnabled(false);
+		} else {
+			getEditAccountButton().setEnabled(true);
+			getCopyUsernameButton().setEnabled(true);
+			getCopyPasswordButton().setEnabled(true);
+			getLaunchURLButton().setEnabled(true);
+			getDeleteAccountButton().setEnabled(true);
+			getEditAccountMenuItem().setEnabled(true);
+			getCopyUsernameMenuItem().setEnabled(true);
+			getCopyPasswordMenuItem().setEnabled(true);
+			getLaunchURLMenuItem().setEnabled(true);
+			getDeleteAccountMenuItem().setEnabled(true);
+			getViewAccountMenuItem().setEnabled(true);
+		}
 	}
 
 	public interface ChangeDatabaseAction {


### PR DESCRIPTION
setButtonState() references MainWindow through methods and fields while it doesn't reference its own class. So, this method fits better in that class.